### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You can install the latest version of Gatsby by following these steps:
 The usual contributing steps are:
 
 * Fork the [official repository](https://github.com/gatsbyjs/gatsby).
-* Clone your fork: git clone `git@github.com:<your-username>/gatsby.git`
+* Clone your fork: `git clone https://github.com/<your-username>/gatsby.git`
 * Setup up repo and install dependencies: `yarn run bootstrap`
 * Make sure tests are passing for you: `yarn test`
 * Create a topic branch: `git checkout -b topics/new-feature-name`


### PR DESCRIPTION
## Description

Line 44 of CONTRIBUTING.md the command is not highlighting `git clone` which is a part of the command block. 

Also the command `git clone git@github.com:<your-username>/gatsby.git` doesn't work for me.

Proposed new command line of `git clone https://github.com/<your-username>/gatsby.git` which does work for me every time.

### Steps to reproduce

By viewing the doc `CONTRIBUTING.md` line 44, also by attempting the command as described: git clone `git@github.com:<your-username>/gatsby.git`

### Expected result

Docs should have the whole command highlighted to eliminate confusion. Also command should properly clone the fork.

### Actual result

`tsanford@Tylers-MacBook-Pro.local:~/Desktop$ git clone git@github.com:tylersanford/hello-world.git
Cloning into 'hello-world'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.`

### Environment

* Gatsby version (`npm list gatsby`): N/A - Doc change
* gatsby-cli version (`gatsby --version`): N/A - Doc change
* Node.js version: node -v: v9.7.1
* Operating System: macOS High Sierra 10.13.4

### File contents (if changed):

`CONTRIBUTION.md`:
`* Clone your fork: `git clone https://github.com/<your-username>/gatsby.git``

